### PR TITLE
Add the mockTokenPriceService to all calls to the SOR constructor in the test suite

### DIFF
--- a/test/elementPools.spec.ts
+++ b/test/elementPools.spec.ts
@@ -1,3 +1,5 @@
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect } from 'chai';
 import { JsonRpcProvider } from '@ethersproject/providers';
@@ -166,7 +168,13 @@ describe(`Tests for Element Pools.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const fetchSuccess = await sor.fetchPools([], false);
         expect(fetchSuccess).to.be.true;
@@ -200,7 +208,13 @@ describe(`Tests for Element Pools.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const fetchSuccess = await sor.fetchPools([], false);
         expect(fetchSuccess).to.be.true;
@@ -234,7 +248,13 @@ describe(`Tests for Element Pools.`, () => {
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('777', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const fetchSuccess = await sor.fetchPools([], false);
         expect(fetchSuccess).to.be.true;
@@ -268,7 +288,13 @@ describe(`Tests for Element Pools.`, () => {
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('777', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const fetchSuccess = await sor.fetchPools([], false);
         expect(fetchSuccess).to.be.true;

--- a/test/elementTrades.spec.ts
+++ b/test/elementTrades.spec.ts
@@ -6,6 +6,8 @@ File saved at: ./testData/elementPools/testTrades.json
 Code to generate test vectors:
 https://github.com/element-fi/elf-contracts/blob/main/scripts/load-sim-data.sh
 */
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect, assert } from 'chai';
 import { JsonRpcProvider } from '@ethersproject/providers';
@@ -99,7 +101,13 @@ describe(`Tests against Element generated test trade file.`, () => {
                     : '0x0000000000000000000000000000000000000001';
             const swapAmt = parseFixed(trade.input.amount_in.toString(), 18);
 
-            const sor = new SOR(provider, chainId, null, poolsFromFile);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                poolsFromFile
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;

--- a/test/lbp.spec.ts
+++ b/test/lbp.spec.ts
@@ -1,3 +1,5 @@
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect } from 'chai';
 import { JsonRpcProvider } from '@ethersproject/providers';
@@ -36,7 +38,13 @@ describe(`Tests for LBP Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -66,7 +74,13 @@ describe(`Tests for LBP Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;

--- a/test/lib/testHelpers.ts
+++ b/test/lib/testHelpers.ts
@@ -22,6 +22,7 @@ import { assert, expect } from 'chai';
 import WeightedTokens from '../testData/eligibleTokens.json';
 import StableTokens from '../testData/stableTokens.json';
 import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
+import { mockTokenPriceService } from './mockTokenPriceService';
 
 export interface TradeInfo {
     SwapType: string;
@@ -355,7 +356,13 @@ export async function getFullSwap(
     swapGas: BigNumber = BigNumber.from('100000'),
     chainId = 1
 ): Promise<SwapInfo> {
-    const sor = new sorv2.SOR(provider, chainId, null, cloneDeep(pools));
+    const sor = new sorv2.SOR(
+        provider,
+        chainId,
+        mockTokenPriceService,
+        null,
+        cloneDeep(pools)
+    );
 
     let swapTypeCorrect = SwapTypes.SwapExactIn;
 

--- a/test/lido.spec.ts
+++ b/test/lido.spec.ts
@@ -1,3 +1,5 @@
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect } from 'chai';
 import cloneDeep from 'lodash.clonedeep';
@@ -82,7 +84,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapAmt = parseFixed('1', 18);
             const priceRate = await getStEthRate(provider, chainId);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -151,7 +159,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapAmt = parseFixed('1', 6);
             const priceRate = await getStEthRate(provider, chainId);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -218,7 +232,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapAmt = parseFixed('1', 18);
             const priceRate = await getStEthRate(provider, chainId);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -283,7 +303,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapAmt = parseFixed('1', 18);
             const priceRate = await getStEthRate(provider, chainId);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -353,7 +379,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -390,7 +422,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -430,7 +468,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -467,7 +511,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -506,7 +556,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 6);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -552,7 +608,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -598,7 +660,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -644,7 +712,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 6);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -692,7 +766,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 6);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -738,7 +818,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -784,7 +870,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -831,7 +923,13 @@ describe(`Tests for Lido USD routes.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 6);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 

--- a/test/metaStablePools.spec.ts
+++ b/test/metaStablePools.spec.ts
@@ -1,3 +1,5 @@
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect } from 'chai';
 import cloneDeep from 'lodash.clonedeep';
@@ -32,7 +34,13 @@ async function getStableComparrison(
     swapType: SwapTypes,
     swapAmt: BigNumber
 ): Promise<SwapInfo> {
-    const sorStable = new SOR(provider, chainId, null, stablePools);
+    const sorStable = new SOR(
+        provider,
+        chainId,
+        mockTokenPriceService,
+        null,
+        stablePools
+    );
     await sorStable.fetchPools([], false);
 
     const swapInfoStable: SwapInfo = await sorStable.getSwaps(
@@ -175,7 +183,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -202,7 +216,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -231,7 +251,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18); // Would expect ~ 2 back
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -299,7 +325,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18); // Would expect ~ 1 back
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -364,7 +396,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('2', 18); // Would expect ~ 1 as input
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -429,7 +467,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('2', 18); // Would expect ~ 4 as input
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -500,7 +544,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('77.723', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
@@ -570,7 +620,13 @@ describe(`Tests for MetaStable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('77.8', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
 
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -1,4 +1,6 @@
 // TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/stablePools.spec.ts
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { expect } from 'chai';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -128,7 +130,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -154,7 +162,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -180,7 +194,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('1', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -217,7 +237,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('1', 6);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -256,7 +282,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactIn;
             const swapAmt = parseFixed('23.45', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 
@@ -298,7 +330,13 @@ describe(`Tests for Stable Pools.`, () => {
             const swapType = SwapTypes.SwapExactOut;
             const swapAmt = parseFixed('17.77', 18);
 
-            const sor = new SOR(provider, chainId, null, pools);
+            const sor = new SOR(
+                provider,
+                chainId,
+                mockTokenPriceService,
+                null,
+                pools
+            );
             const fetchSuccess = await sor.fetchPools([], false);
             expect(fetchSuccess).to.be.true;
 

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -1,4 +1,6 @@
 // Example showing SOR with Vault batchSwap and Subgraph pool data, run using: $ TS_NODE_PROJECT='tsconfig.testing.json' ts-node ./test/testScripts/swapExample.ts
+import { mockTokenPriceService } from '../lib/mockTokenPriceService';
+
 require('dotenv').config();
 import {
     BigNumber,
@@ -244,7 +246,12 @@ async function getSwap(
     swapType: SwapTypes,
     swapAmount: BigNumberish
 ): Promise<SwapInfo> {
-    const sor = new SOR(provider, networkId, poolsSource);
+    const sor = new SOR(
+        provider,
+        networkId,
+        mockTokenPriceService,
+        poolsSource
+    );
 
     // Will get onChain data for pools list
     await sor.fetchPools([], queryOnChain);

--- a/test/wrapper.spec.ts
+++ b/test/wrapper.spec.ts
@@ -1,4 +1,6 @@
 // TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/wrapper.spec.ts
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
+
 require('dotenv').config();
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { AddressZero, Zero } from '@ethersproject/constants';
@@ -23,7 +25,7 @@ const poolsUrl = `https://ipfs.fleek.co/ipns/balancer-team-bucket.storage.fleek.
 
 describe(`Tests for wrapper class.`, () => {
     it(`Should set constructor variables`, () => {
-        const sor = new SOR(provider, chainId, poolsUrl);
+        const sor = new SOR(provider, chainId, mockTokenPriceService, poolsUrl);
         assert.equal(provider, sor.provider);
     });
 
@@ -32,7 +34,7 @@ describe(`Tests for wrapper class.`, () => {
         const tokenOut = DAI.address;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = Zero;
-        const sor = new SOR(provider, chainId, poolsUrl);
+        const sor = new SOR(provider, chainId, mockTokenPriceService, poolsUrl);
         const swaps: SwapInfo = await sor.getSwaps(
             tokenIn,
             tokenOut,
@@ -54,7 +56,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -102,7 +110,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -142,7 +156,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         const result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -217,7 +237,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         let result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -281,7 +307,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 6);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         let result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -344,7 +376,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('0.1', 6);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         let result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);
@@ -403,7 +441,13 @@ describe(`Tests for wrapper class.`, () => {
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('0.1', 18);
 
-        const sor = new SOR(provider, chainId, null, pools);
+        const sor = new SOR(
+            provider,
+            chainId,
+            mockTokenPriceService,
+            null,
+            pools
+        );
 
         let result: boolean = await sor.fetchPools([], false);
         assert.isTrue(result);


### PR DESCRIPTION
Extension to: https://github.com/balancer-labs/balancer-sor/pull/222

The constructor arguments were changed for the SOR, so we needed to update every call to it, which creates what seems like a large PR, but is only doing a single thing.