### PR TITLE
Refactor the tests to work with the SorConfig

### DIFF
--- a/test/elementPools.spec.ts
+++ b/test/elementPools.spec.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
+
+import { sorConfigEth } from './lib/constants';
 import { expect } from 'chai';
 import { mockTokenPriceService } from './lib/mockTokenPriceService';
 import { JsonRpcProvider } from '@ethersproject/providers';
@@ -21,7 +23,6 @@ import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
@@ -31,6 +32,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`tests getLimitAmountSwap SwapExactOut`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pool = poolsFromFile.pools[0];
         const swapType = SwapTypes.SwapExactOut;
@@ -74,6 +76,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`tests getLimitAmountSwap SwapExactIn, within expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pool = poolsFromFile.pools[0];
         const swapType = SwapTypes.SwapExactIn;
@@ -118,6 +121,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`tests getLimitAmountSwap SwapExactIn, outwith expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pool = poolsFromFile.pools[0];
         const swapType = SwapTypes.SwapExactIn;
@@ -162,6 +166,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`Full Swap - swapExactIn Direct Pool, Within Expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pools = poolsFromFile.pools;
         const tokenIn = '0x0000000000000000000000000000000000000001';
@@ -171,7 +176,7 @@ describe(`Tests for Element Pools.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -201,6 +206,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`Full Swap - swapExactIn Direct Pool, Outwith Expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pools = poolsFromFile.pools;
         const tokenIn = '0x0000000000000000000000000000000000000001';
@@ -210,7 +216,7 @@ describe(`Tests for Element Pools.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -240,6 +246,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`Full Swap - swapExactOut Direct Pool, Within Expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pools = poolsFromFile.pools;
         const tokenIn = '0x0000000000000000000000000000000000000001';
@@ -249,7 +256,7 @@ describe(`Tests for Element Pools.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -279,6 +286,7 @@ describe(`Tests for Element Pools.`, () => {
     it(`Full Swap - swapExactOut Direct Pool, Outwith Expiry`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/elementPools/elementFinanceTest1.json');
         const pools = poolsFromFile.pools;
         const tokenIn = '0x0000000000000000000000000000000000000001';
@@ -288,7 +296,7 @@ describe(`Tests for Element Pools.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );

--- a/test/elementTrades.spec.ts
+++ b/test/elementTrades.spec.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import { MockPoolDataService } from './lib/mockPoolDataService';
-
 require('dotenv').config();
+
 /*
 npx mocha -r ts-node/register test/elementTrades.spec.ts
 
@@ -16,13 +15,14 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { SOR, SwapInfo, SwapTypes } from '../src';
 import { calcRelativeDiffBn } from './lib/testHelpers';
 import { PoolFilter, SubgraphPoolBase } from '../src/types';
+import { MockPoolDataService } from './lib/mockPoolDataService';
+import { sorConfigEth } from './lib/constants';
 
 import testTrades from './testData/elementPools/testTrades.json';
 import { parseFixed } from '@ethersproject/bignumber';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
@@ -105,7 +105,7 @@ describe(`Tests against Element generated test trade file.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(poolsFromFile),
                 mockTokenPriceService
             );

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -6,12 +6,11 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 
 import { formatSwaps } from '../src/formatSwaps';
 import { getWrappedInfo, setWrappedInfo } from '../src/wrapInfo';
-import { WETHADDR } from '../src/constants';
 import { Lido } from '../src/pools/lido';
 import { Swap, SwapInfo, SwapTypes, SwapV2 } from '../src/types';
 import { bnum } from '../src/utils/bignumber';
 import testSwaps from './testData/swapsForFormatting.json';
-import { BAL, DAI, GUSD, USDC, WETH } from './lib/constants';
+import { BAL, DAI, GUSD, sorConfigEth, USDC, WETH } from './lib/constants';
 
 const marketSp = '7';
 
@@ -1342,14 +1341,14 @@ describe(`Tests for Helpers.`, () => {
             };
 
             const swapInfo: SwapInfo = {
-                tokenAddresses: [WETHADDR[chainId], BAL.address],
+                tokenAddresses: [sorConfigEth.weth, BAL.address],
                 swaps: [swap, swap], // Doesn't need valid swaps for this
                 swapAmount,
                 swapAmountForSwaps: Zero, // This isn't set until after setWrappedInfo
                 returnAmount,
                 returnAmountConsideringFees: returnAmount,
                 returnAmountFromSwaps: Zero, // This isn't set until after setWrappedInfo
-                tokenIn: WETHADDR[chainId],
+                tokenIn: sorConfigEth.weth,
                 tokenOut: BAL.address,
                 marketSp: Zero.toString(),
             };
@@ -1359,7 +1358,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1367,7 +1366,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1408,14 +1407,14 @@ describe(`Tests for Helpers.`, () => {
             };
 
             const swapInfo: SwapInfo = {
-                tokenAddresses: [WETHADDR[chainId], BAL.address],
+                tokenAddresses: [sorConfigEth.weth, BAL.address],
                 swaps: [swap, swap], // Doesn't need valid swaps for this
                 swapAmount,
                 swapAmountForSwaps: Zero, // This isn't set until after setWrappedInfo
                 returnAmount,
                 returnAmountConsideringFees: returnAmount,
                 returnAmountFromSwaps: Zero, // This isn't set until after setWrappedInfo
-                tokenIn: WETHADDR[chainId],
+                tokenIn: sorConfigEth.weth,
                 tokenOut: BAL.address,
                 marketSp: Zero.toString(),
             };
@@ -1425,7 +1424,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1433,7 +1432,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1474,7 +1473,7 @@ describe(`Tests for Helpers.`, () => {
             };
 
             const swapInfo: SwapInfo = {
-                tokenAddresses: [BAL.address, WETHADDR[chainId]],
+                tokenAddresses: [BAL.address, sorConfigEth.weth],
                 swaps: [swap, swap], // Doesn't need valid swaps for this
                 swapAmount,
                 swapAmountForSwaps: Zero, // This isn't set until after setWrappedInfo
@@ -1482,7 +1481,7 @@ describe(`Tests for Helpers.`, () => {
                 returnAmountFromSwaps: Zero, // This isn't set until after setWrappedInfo
                 returnAmountConsideringFees: returnAmount,
                 tokenIn: BAL.address,
-                tokenOut: WETHADDR[chainId],
+                tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
             };
 
@@ -1491,7 +1490,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1499,7 +1498,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1540,7 +1539,7 @@ describe(`Tests for Helpers.`, () => {
             };
 
             const swapInfo: SwapInfo = {
-                tokenAddresses: [BAL.address, WETHADDR[chainId]],
+                tokenAddresses: [BAL.address, sorConfigEth.weth],
                 swaps: [swap, swap], // Doesn't need valid swaps for this
                 swapAmount,
                 swapAmountForSwaps: Zero, // This isn't set until after setWrappedInfo
@@ -1548,7 +1547,7 @@ describe(`Tests for Helpers.`, () => {
                 returnAmountFromSwaps: Zero, // This isn't set until after setWrappedInfo
                 returnAmountConsideringFees: returnAmount,
                 tokenIn: BAL.address,
-                tokenOut: WETHADDR[chainId],
+                tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
             };
 
@@ -1557,7 +1556,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1565,7 +1564,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1623,7 +1622,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1631,7 +1630,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1691,7 +1690,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1699,7 +1698,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1759,7 +1758,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1767,7 +1766,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1830,7 +1829,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1838,7 +1837,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([
@@ -1885,7 +1884,7 @@ describe(`Tests for Helpers.`, () => {
             };
 
             const swapInfo: SwapInfo = {
-                tokenAddresses: [Lido.wstETH[chainId], WETHADDR[chainId]],
+                tokenAddresses: [Lido.wstETH[chainId], sorConfigEth.weth],
                 swaps: [swap, swap], // Doesn't need valid swaps for this
                 swapAmount,
                 swapAmountForSwaps: Zero, // This isn't set until after setWrappedInfo
@@ -1893,7 +1892,7 @@ describe(`Tests for Helpers.`, () => {
                 returnAmountFromSwaps: Zero, // This isn't set until after setWrappedInfo
                 returnAmountConsideringFees: returnAmount,
                 tokenIn: Lido.wstETH[chainId],
-                tokenOut: WETHADDR[chainId],
+                tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
             };
 
@@ -1902,7 +1901,7 @@ describe(`Tests for Helpers.`, () => {
                 swapType,
                 tokenIn,
                 tokenOut,
-                chainId,
+                sorConfigEth,
                 swapAmount
             );
 
@@ -1910,7 +1909,7 @@ describe(`Tests for Helpers.`, () => {
                 swapInfo,
                 swapType,
                 wrappedInfo,
-                chainId
+                sorConfigEth
             );
 
             expect(swapInfoUpdated.tokenAddresses).to.deep.eq([

--- a/test/lbp.spec.ts
+++ b/test/lbp.spec.ts
@@ -1,17 +1,17 @@
-import { mockTokenPriceService } from './lib/mockTokenPriceService';
-
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
+
+import { mockTokenPriceService } from './lib/mockTokenPriceService';
 import { expect } from 'chai';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { SOR } from '../src';
 import { SwapInfo, SwapTypes, SubgraphPoolBase } from '../src/types';
 import { parseFixed } from '@ethersproject/bignumber';
-import { DAI, USDC } from './lib/constants';
+import { DAI, sorConfigEth, USDC } from './lib/constants';
 import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
@@ -31,6 +31,7 @@ describe(`Tests for LBP Pools.`, () => {
         it(`Full Swap - swapExactIn, Swaps not paused so should have route`, async () => {
             const poolsFromFile: {
                 pools: SubgraphPoolBase[];
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
             } = require('./testData/lbpPools/singlePool.json');
             const pools = poolsFromFile.pools;
 
@@ -41,7 +42,7 @@ describe(`Tests for LBP Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -65,6 +66,7 @@ describe(`Tests for LBP Pools.`, () => {
         it(`Full Swap - swapExactIn, Swaps paused so should have no route`, async () => {
             const poolsFromFile: {
                 pools: SubgraphPoolBase[];
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
             } = require('./testData/lbpPools/singlePool.json');
             const pools = poolsFromFile.pools;
             // Set paused to true
@@ -76,7 +78,7 @@ describe(`Tests for LBP Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );

--- a/test/lido.spec.ts
+++ b/test/lido.spec.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
+
+import { sorConfigEth } from './lib/constants';
 import { MockPoolDataService } from './lib/mockPoolDataService';
 import { mockTokenPriceService } from './lib/mockTokenPriceService';
 import { expect } from 'chai';
@@ -88,7 +90,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -162,7 +164,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -234,7 +236,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -304,7 +306,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -379,7 +381,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -421,7 +423,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -466,7 +468,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -508,7 +510,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -552,7 +554,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -603,7 +605,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -654,7 +656,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -705,7 +707,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -758,7 +760,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -809,7 +811,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -860,7 +862,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -912,7 +914,7 @@ describe(`Tests for Lido USD routes.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -2,7 +2,7 @@
 import { assert, expect } from 'chai';
 import cloneDeep from 'lodash.clonedeep';
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { BigNumber, parseFixed, formatFixed } from '@ethersproject/bignumber';
+import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { BigNumber as OldBigNumber, bnum } from '../src/utils/bignumber';
 import {
     PoolDictionary,
@@ -10,7 +10,8 @@ import {
     SwapTypes,
     PoolTypes,
     SubgraphPoolBase,
-} from '../src/types';
+    SorConfig,
+} from '../src';
 import {
     filterPoolsOfInterest,
     filterHopPools,
@@ -40,6 +41,8 @@ import {
     aUSDT,
     KOVAN_BAL,
     AAVE_USDT,
+    sorConfigTest,
+    sorConfigKovan,
 } from './lib/constants';
 
 // Single Linear pool DAI/aDAI/bDAI
@@ -48,9 +51,6 @@ import singleLinear from './testData/linearPools/singleLinear.json';
 import smallLinear from './testData/linearPools/smallLinear.json';
 import kovanPools from './testData/linearPools/kovan.json';
 import fullKovanPools from './testData/linearPools/fullKovan.json';
-
-const chainId = 99;
-const MAX_TOKEN_BALANCE = BigNumber.from('2').pow('112').sub('1');
 
 describe('linear pool tests', () => {
     context('parsePoolPairData', () => {
@@ -658,7 +658,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactIn,
                     parseFixed('10.23098', DAI.decimals),
                     kovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('10127143');
             });
@@ -674,7 +674,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactOut,
                     parseFixed('0.123456', USDT.decimals),
                     pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('124721185153919559');
             });
@@ -688,7 +688,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactIn,
                     parseFixed('7.21', AAVE_USDT.decimals),
                     fullKovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 // 6605808981785744500
                 expect(returnAmount).to.eq('6606146264948964392');
@@ -701,7 +701,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactIn,
                     parseFixed('10.8248', KOVAN_BAL.decimals),
                     fullKovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 // 11062044
                 expect(returnAmount).to.eq('11061470');
@@ -714,7 +714,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactOut,
                     parseFixed('0.652413919893769122', KOVAN_BAL.decimals),
                     fullKovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('702055');
             });
@@ -726,7 +726,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactOut,
                     parseFixed('71.990116', AAVE_USDT.decimals),
                     fullKovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
 
                 // 81894035538462519296
@@ -744,7 +744,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactIn,
                     parseFixed('1', DAI.decimals),
                     pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('989985749906811070');
             });
@@ -756,7 +756,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactOut,
                     parseFixed('1', STABAL3PHANTOM.decimals),
                     kovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('1009969');
             });
@@ -768,7 +768,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactIn,
                     parseFixed('1', STABAL3PHANTOM.decimals),
                     kovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('989869');
             });
@@ -780,7 +780,7 @@ describe('linear pool tests', () => {
                     SwapTypes.SwapExactOut,
                     parseFixed('1', USDT.decimals),
                     kovanPools.pools,
-                    42
+                    sorConfigKovan
                 );
                 expect(returnAmount).to.eq('1010233805404347502');
             });
@@ -840,7 +840,7 @@ function getPaths(
         tokenOut,
         poolsAll,
         poolsFilteredDict,
-        chainId
+        sorConfigTest
     );
     pathData = pathData.concat(pathsUsingLinear);
     const [paths] = calculatePathLimits(pathData, swapType);
@@ -853,7 +853,7 @@ async function testFullSwap(
     swapType: SwapTypes,
     swapAmount: BigNumber,
     pools: SubgraphPoolBase[],
-    chainId = 99
+    config: SorConfig = sorConfigTest
 ) {
     const returnAmountDecimals = 18; // TO DO Remove?
     const maxPools = 4;
@@ -877,7 +877,7 @@ async function testFullSwap(
         gasPrice,
         provider,
         swapGas,
-        chainId
+        config
     );
 
     const totalSwapAmount = getTotalSwapAmount(swapType, swapInfo);

--- a/test/metaStablePools.spec.ts
+++ b/test/metaStablePools.spec.ts
@@ -8,18 +8,17 @@ import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as ONE } from '@ethersproject/constants';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { SOR } from '../src';
-import { SwapInfo, SwapTypes, PoolTypes, SubgraphPoolBase } from '../src/types';
+import { SwapInfo, SwapTypes, PoolTypes, SubgraphPoolBase } from '../src';
 import { bnum } from '../src/utils/bignumber';
 import {
     MetaStablePool,
     MetaStablePoolPairData,
 } from '../src/pools/metaStablePool/metaStablePool';
-import { BAL, USDC, WETH } from './lib/constants';
+import { BAL, sorConfigEth, USDC, WETH } from './lib/constants';
 import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
@@ -38,7 +37,7 @@ async function getStableComparrison(
 ): Promise<SwapInfo> {
     const sorStable = new SOR(
         provider,
-        chainId,
+        sorConfigEth,
         new MockPoolDataService(stablePools),
         mockTokenPriceService
     );
@@ -62,6 +61,7 @@ async function getStableComparrison(
 describe(`Tests for MetaStable Pools.`, () => {
     context('limit amounts', () => {
         it(`tests getLimitAmountSwap SwapExactIn`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pool = cloneDeep(poolsFromFile.metaStablePool[0]);
             const swapType = SwapTypes.SwapExactIn;
@@ -119,6 +119,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         });
 
         it(`tests getLimitAmountSwap SwapExactOut`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pool = cloneDeep(poolsFromFile.metaStablePool[0]);
             const swapType = SwapTypes.SwapExactOut;
@@ -175,6 +176,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
     context('direct pool', () => {
         it(`Full Swap - swapExactIn No Route`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -186,7 +188,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -207,6 +209,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         });
 
         it(`Full Swap - swapExactOut No Route`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -218,7 +221,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -239,6 +242,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         });
 
         it(`Full Swap - swapExactIn, Token ETH >Token Meta`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -252,7 +256,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -313,6 +317,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         }).timeout(10000);
 
         it(`Full Swap - swapExactIn, Token Meta > Token ETH`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -325,7 +330,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -383,6 +388,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         }).timeout(10000);
 
         it(`Full Swap - swapExactOut, Token ETH >Token Meta`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -395,7 +401,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -452,6 +458,7 @@ describe(`Tests for MetaStable Pools.`, () => {
         }).timeout(10000);
 
         it(`Full Swap - swapExactOut, Token Meta > Token ETH`, async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/singlePool.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePool
@@ -465,7 +472,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -528,6 +535,7 @@ describe(`Tests for MetaStable Pools.`, () => {
     context('multihop', () => {
         it(`Full Swap - swapExactIn, Token>Token`, async () => {
             // With meta token as hop the result in/out should be same as a normal stable pool
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/multihop.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePools
@@ -541,7 +549,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -603,6 +611,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
         it(`Full Swap - swapExactOut, Token>Token`, async () => {
             // With meta token as hop the result in/out should be same as a normal stable pool
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const poolsFromFile = require('./testData/metaStablePools/multihop.json');
             const pools: SubgraphPoolBase[] = cloneDeep(
                 poolsFromFile.metaStablePools
@@ -616,7 +625,7 @@ describe(`Tests for MetaStable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );

--- a/test/phantomStablePools.spec.ts
+++ b/test/phantomStablePools.spec.ts
@@ -12,6 +12,7 @@ import {
     LINEAR_AUSDT,
     STABAL3PHANTOM,
     LINEAR_ADAI,
+    sorConfigKovan,
 } from './lib/constants';
 import poolsFromFile from './testData/phantomStablePools/phantomStablePool.json';
 import { SubgraphPoolBase, SwapTypes } from '../src';
@@ -225,8 +226,6 @@ describe(`Tests for PhantomStable Pools.`, () => {
     });
 });
 
-const chainId = 42;
-
 async function testFullSwap(
     tokenIn: string,
     tokenOut: string,
@@ -256,7 +255,7 @@ async function testFullSwap(
         gasPrice,
         provider,
         swapGas,
-        chainId
+        sorConfigKovan
     );
 
     const totalSwapAmount = getTotalSwapAmount(swapType, swapInfo);

--- a/test/routeProposer.spec.ts
+++ b/test/routeProposer.spec.ts
@@ -1,40 +1,40 @@
 // npx mocha -r ts-node/register test/wrapper.spec.ts
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
 import { parseFixed } from '@ethersproject/bignumber';
 import { expect } from 'chai';
 
 import { RouteProposer } from '../src/routeProposal';
 import { SwapTypes, SubgraphPoolBase, SwapOptions } from '../src/types';
-import { DAI, WETH } from './lib/constants';
+import { DAI, sorConfigTest, WETH } from './lib/constants';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 99;
 
 describe(`RouteProposer.`, () => {
     it(`should have no cached process data on creation`, () => {
-        const routeProposer = new RouteProposer();
+        const routeProposer = new RouteProposer(sorConfigTest);
         expect(routeProposer.cache).to.deep.eq({});
     });
 
     it(`should save cached data correctly`, async () => {
         const poolsFromFile: {
             pools: SubgraphPoolBase[];
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
         const tokenIn = WETH.address;
         const tokenOut = DAI.address;
         const swapType = SwapTypes.SwapExactIn;
 
-        const routeProposer = new RouteProposer();
+        const routeProposer = new RouteProposer(sorConfigTest);
 
         await routeProposer.getCandidatePaths(
             tokenIn,
             tokenOut,
             swapType,
             pools,
-            { gasPrice, maxPools, timestamp: 0 } as SwapOptions,
-            chainId
+            { gasPrice, maxPools, timestamp: 0 } as SwapOptions
         );
 
         const cacheZero =
@@ -48,8 +48,7 @@ describe(`RouteProposer.`, () => {
             tokenOut,
             swapType,
             pools,
-            { gasPrice, maxPools, timestamp: 1 } as SwapOptions,
-            chainId
+            { gasPrice, maxPools, timestamp: 1 } as SwapOptions
         );
 
         const cacheZeroRepeat =

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../src/pools/stablePool/stablePool';
 import { BPTForTokensZeroPriceImpact } from '../src/frontendHelpers/stableHelpers';
 import { parseFixed } from '@ethersproject/bignumber';
-import { BAL, DAI, USDC, USDT } from './lib/constants';
+import { BAL, DAI, sorConfigEth, USDC, USDT } from './lib/constants';
 import { Zero } from '@ethersproject/constants';
 import { MockPoolDataService } from './lib/mockPoolDataService';
 
@@ -32,7 +32,6 @@ const multihopPoolsFromFile: {
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
@@ -139,7 +138,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -167,7 +166,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -195,7 +194,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -234,7 +233,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -275,7 +274,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );
@@ -323,7 +322,7 @@ describe(`Tests for Stable Pools.`, () => {
 
             const sor = new SOR(
                 provider,
-                chainId,
+                sorConfigEth,
                 new MockPoolDataService(pools),
                 mockTokenPriceService
             );

--- a/test/swapCostCalculator.spec.ts
+++ b/test/swapCostCalculator.spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { BigNumber } from '@ethersproject/bignumber';
 import { SwapCostCalculator } from '../src/swapCostCalculator';
-import { DAI, MKR, USDC, WETH } from './lib/constants';
+import { DAI, MKR, sorConfigEth, USDC, WETH } from './lib/constants';
 import { MockTokenPriceService } from './lib/mockTokenPriceService';
 
 describe('Test SwapCostCalculator', () => {
@@ -12,7 +12,7 @@ describe('Test SwapCostCalculator', () => {
             const swapGas = BigNumber.from('100000');
             const costExpected = BigNumber.from('0');
 
-            const cost = await new SwapCostCalculator(1, {
+            const cost = await new SwapCostCalculator(sorConfigEth, {
                 getNativeAssetPriceInToken(): Promise<string> {
                     throw new Error('unrecognized token');
                 },
@@ -29,7 +29,7 @@ describe('Test SwapCostCalculator', () => {
             const swapCostInDAI = BigNumber.from('12000000000000000000');
 
             const cost = await new SwapCostCalculator(
-                1,
+                sorConfigEth,
                 new MockTokenPriceService(ethPrice.div(daiPrice).toString())
             ).convertGasCostToToken(
                 DAI.address,
@@ -49,7 +49,7 @@ describe('Test SwapCostCalculator', () => {
             const swapCostInUSDC = BigNumber.from('12000000');
 
             const cost = await new SwapCostCalculator(
-                1,
+                sorConfigEth,
                 new MockTokenPriceService(ethPrice.div(usdcPrice).toString())
             ).convertGasCostToToken(
                 USDC.address,
@@ -69,7 +69,7 @@ describe('Test SwapCostCalculator', () => {
             const swapCostInMKR = BigNumber.from('3000000000000000'); //0.003
 
             const cost = await new SwapCostCalculator(
-                1,
+                sorConfigEth,
                 new MockTokenPriceService(ethPrice.div(mkrPrice).toString())
             ).convertGasCostToToken(
                 MKR.address,
@@ -86,7 +86,7 @@ describe('Test SwapCostCalculator', () => {
             const swapGas = BigNumber.from('100000');
 
             const cost = await new SwapCostCalculator(
-                1,
+                sorConfigEth,
                 new MockTokenPriceService('1')
             ).convertGasCostToToken(
                 WETH.address,

--- a/test/weightedPools.spec.ts
+++ b/test/weightedPools.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
 import { expect } from 'chai';
 import { SwapTypes, PoolTypes, SubgraphPoolBase } from '../src/types';
@@ -14,6 +15,7 @@ describe(`Tests for Weighted Pools.`, () => {
         it(`tests getLimitAmountSwap SwapExactIn`, async () => {
             const poolsFromFile: {
                 pools: SubgraphPoolBase[];
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
             } = require('./testData/weightedPools/singlePool.json');
             const pool = poolsFromFile.pools[0];
             const swapType = SwapTypes.SwapExactIn;
@@ -53,6 +55,7 @@ describe(`Tests for Weighted Pools.`, () => {
         it(`tests getLimitAmountSwap SwapExactOut`, async () => {
             const poolsFromFile: {
                 pools: SubgraphPoolBase[];
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
             } = require('./testData/weightedPools/singlePool.json');
             const pool = poolsFromFile.pools[0];
             const swapType = SwapTypes.SwapExactOut;

--- a/test/wrapper.spec.ts
+++ b/test/wrapper.spec.ts
@@ -10,7 +10,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { assert, expect } from 'chai';
 import { SOR } from '../src';
 import { SwapInfo, SwapTypes, PoolFilter, SubgraphPoolBase } from '../src';
-import { DAI, USDC, WETH } from './lib/constants';
+import { DAI, sorConfigEth, USDC, WETH } from './lib/constants';
 import {
     MockPoolDataService,
     mockPoolDataService,
@@ -26,13 +26,12 @@ const provider = new JsonRpcProvider(
 );
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const chainId = 1;
 
 describe(`Tests for wrapper class.`, () => {
     it(`Should set constructor variables`, () => {
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             mockPoolDataService,
             mockTokenPriceService
         );
@@ -46,7 +45,7 @@ describe(`Tests for wrapper class.`, () => {
         const swapAmt = Zero;
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             mockPoolDataService,
             mockTokenPriceService
         );
@@ -70,7 +69,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -119,7 +118,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -160,7 +159,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -236,7 +235,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -301,7 +300,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -366,7 +365,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );
@@ -427,7 +426,7 @@ describe(`Tests for wrapper class.`, () => {
 
         const sor = new SOR(
             provider,
-            chainId,
+            sorConfigEth,
             new MockPoolDataService(pools),
             mockTokenPriceService
         );


### PR DESCRIPTION
This is an extension to PR #4, it's been separated out so that it's possible to read the original PR stand alone.

This extension simply refactors the tests to work with the `SorConfig`.

This PR builds on balancer-labs#222, balancer-labs#223, #2, #4.